### PR TITLE
Multiple fixes to AutoSeller

### DIFF
--- a/Props-AutomatedSelling/package.json
+++ b/Props-AutomatedSelling/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Props Automated Selling",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "main": "src/PAutoSell.js",
     "license": "MIT",
     "author": "Props",

--- a/Props-AutomatedSelling/src/PAutoSell.ts
+++ b/Props-AutomatedSelling/src/PAutoSell.ts
@@ -222,6 +222,11 @@ class PAutoSell implements IPreAkiLoadMod, IPostAkiLoadMod {
 
 		//log total roubles earned
 		this.logger.info(`PAutoSell: Total Roubles earned: ${currencyAmount} and sent to stash`);
+
+		//don't create roubles stack if total is 0 or invalid
+		if (currencyAmount <= 0) {
+			return;
+		}
 		
 		//generate a new item with the currency
 		const playerMoney: Item = {

--- a/Props-AutomatedSelling/src/PAutoSell.ts
+++ b/Props-AutomatedSelling/src/PAutoSell.ts
@@ -322,10 +322,16 @@ class PAutoSell implements IPreAkiLoadMod, IPostAkiLoadMod {
 		}
 		
 		const trader = this.databaseServer.getTables().traders[traderId].base;
-		const price = this.traderHelper.getHighestSellToTraderPrice(item._tpl) * this.modConfig.PriceMultiplier; //apparently price already includes currency conversion to rubles
-		const itemName = this.getItemName(item._tpl);
 
-		this.logger.info(`Selling item ${itemName} to trader ${trader.nickname} for ${price} RUB`);
+		//apparently price already includes currency conversion to rubles; rounding due to multiplication and decimals
+		const priceItem = Math.floor(this.traderHelper.getHighestSellToTraderPrice(item._tpl) * this.modConfig.PriceMultiplier); 
+
+		//item can be stackable (bullets, etc) so we need to multiply by the number in the stack
+		const stackObjectCount =  item.upd?.StackObjectsCount ?? 1;
+		const price = priceItem * stackObjectCount;
+
+		const itemName = this.getItemName(item._tpl);
+		this.logger.info(`Selling item ${itemName} to trader ${trader.nickname} for ${priceItem} RUB (${price} RUB total)`);
 
 		// Update the sales sum for the trader
 		this.updateTraderSalesSum(traderId, price, sessionId);


### PR DESCRIPTION
Bugfixes:
1. Autoseller should update the amount to traders into their currency and in a rounded amount
    https://github.com/dvize/SPT-TypeScript/issues/14
2. Autoseller should not create a stack of rubles if no items were sold 
    https://github.com/dvize/SPT-TypeScript/issues/13
3. Autoseller should sell an item by taking into account the stackable amount of that item
    (found this one this morning)
    
3:
![image](https://github.com/dvize/SPT-TypeScript/assets/3286305/87ef6c3b-9993-4135-9a06-d7a62a5824d0)
![image](https://github.com/dvize/SPT-TypeScript/assets/3286305/e2d52eb3-202f-4555-8302-247c1af688f2)
![image](https://github.com/dvize/SPT-TypeScript/assets/3286305/f60c5e2c-b3a3-4955-888e-e3df73508651)
![image](https://github.com/dvize/SPT-TypeScript/assets/3286305/d1639d21-42bf-4066-9fda-45d62ccbbb8f)
